### PR TITLE
Add sticky note support

### DIFF
--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { PresenterSettings, RecordingSource } from './VideoPresenter'
-import { Eye, EyeOff, Square, Circle, CornerUpRight, Settings, Maximize2, RotateCcw, Video, Download, Type, Camera, FileVideo, Hexagon, Diamond, Heart, Star, Upload, X } from 'lucide-react'
+import { Eye, EyeOff, Square, Circle, CornerUpRight, Settings, Maximize2, RotateCcw, Video, Download, Type, Camera, FileVideo, FileText, Hexagon, Diamond, Heart, Star, Upload, X } from 'lucide-react'
 import { useRef, useEffect } from 'react'
 import { useTranslation } from '@/lib/useTranslation'
 import { type ExportFormat, type ConversionProgress, videoExporter } from '@/lib/videoConverter'
@@ -29,6 +29,7 @@ interface ControlsPanelProps {
   onPictureInPicture: () => void
   onToggleTeleprompter: () => void
   onToggleCameraPopup: () => void
+  onAddNote: () => void
   exportFormat: ExportFormat
   onExportFormatChange: (format: ExportFormat) => void
   isConverting: boolean
@@ -51,6 +52,7 @@ export default function ControlsPanel({
   onPictureInPicture,
   onToggleTeleprompter,
   onToggleCameraPopup,
+  onAddNote,
   exportFormat,
   onExportFormatChange,
   isConverting,
@@ -836,18 +838,27 @@ export default function ControlsPanel({
             </div>
           </div>
           
-          <Button 
-            variant="ghost" 
-            size="sm" 
+          <Button
+            variant="ghost"
+            size="sm"
             className="text-sm w-full justify-start"
             onClick={onToggleTeleprompter}
           >
             <Type className="mr-2 h-4 w-4" />
             {mounted ? t.teleprompter : 'Teleprompter'}
           </Button>
-          <Button 
-            variant="ghost" 
-            size="sm" 
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-sm w-full justify-start"
+            onClick={onAddNote}
+          >
+            <FileText className="mr-2 h-4 w-4" />
+            {mounted ? t.addNote : 'Add Note'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
             className="text-sm w-full justify-start"
             onClick={onToggleCameraPopup}
           >

--- a/src/components/VideoPresenter.tsx
+++ b/src/components/VideoPresenter.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect, useCallback } from 'react'
-import VideoCanvas from './VideoCanvas'
+import VideoCanvas, { type VideoCanvasHandle } from './VideoCanvas'
 import ControlsPanel from './ControlsPanel'
 import TopBar from './TopBar'
 import Teleprompter from './Teleprompter'
@@ -50,6 +50,7 @@ export default function VideoPresenter() {
   const [isSidebarVisible, setIsSidebarVisible] = useState(true)
 
   const videoRef = useRef<HTMLVideoElement>(null)
+  const videoCanvasRef = useRef<VideoCanvasHandle>(null)
   const streamRef = useRef<MediaStream | null>(null)
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const recordingTimerRef = useRef<NodeJS.Timeout | null>(null)
@@ -671,6 +672,10 @@ export default function VideoPresenter() {
     setIsSidebarVisible(!isSidebarVisible)
   }, [isSidebarVisible])
 
+  const handleAddNote = () => {
+    videoCanvasRef.current?.addNote()
+  }
+
   const openCameraPopup = () => {
     const popup = window.open(
       '',
@@ -852,6 +857,7 @@ export default function VideoPresenter() {
         {/* Main video area */}
         <div className="flex-1 relative overflow-hidden">
           <VideoCanvas
+            ref={videoCanvasRef}
             videoRef={videoRef}
             settings={settings}
             onSettingsChange={setSettings}
@@ -904,6 +910,7 @@ export default function VideoPresenter() {
               onPictureInPicture={handlePictureInPicture}
               onToggleTeleprompter={handleToggleTeleprompter}
               onToggleCameraPopup={handleToggleCameraPopup}
+              onAddNote={handleAddNote}
               exportFormat={exportFormat}
               onExportFormatChange={setExportFormat}
               isConverting={isConverting}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -90,6 +90,7 @@ export interface Translations {
   teleprompter: string
   cameraPopup: string
   advancedOptions: string
+  addNote: string
   
   // Sidebar
   hideSidebar: string
@@ -197,6 +198,7 @@ export const translations: Record<Language, Translations> = {
     teleprompter: 'Teleprompter',
     cameraPopup: 'Camera Popup',
     advancedOptions: 'Advanced options',
+    addNote: 'Add Note',
     
     // Sidebar
     hideSidebar: 'Hide sidebar (Tab)',
@@ -303,6 +305,7 @@ export const translations: Record<Language, Translations> = {
     teleprompter: 'Teleprompter',
     cameraPopup: 'Pop-up da Câmera',
     advancedOptions: 'Opções avançadas',
+    addNote: 'Adicionar nota',
     
     // Sidebar
     hideSidebar: 'Ocultar barra lateral (Tab)',


### PR DESCRIPTION
## Summary
- allow sticky notes on the presentation board
- expose `addNote` via `VideoCanvas` ref
- add 'Add Note' action in controls panel
- provide translations for the new feature

## Testing
- `npm install`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_b_6865b2b5aae48333b624dc6bbb093ee0