### PR TITLE
Enable scroll zoom with mouse wheel

### DIFF
--- a/src/components/VideoCanvas.tsx
+++ b/src/components/VideoCanvas.tsx
@@ -651,11 +651,9 @@ const VideoCanvas = forwardRef<VideoCanvasHandle, VideoCanvasProps>(function Vid
   }, [])
 
   const handleWheel = useCallback((e: WheelEvent) => {
-    if (e.ctrlKey || e.metaKey) {
-      e.preventDefault()
-      const zoomFactor = e.deltaY > 0 ? -0.1 : 0.1
-      setZoomLevel(prev => Math.max(0.1, Math.min(3, prev + zoomFactor)))
-    }
+    e.preventDefault()
+    const zoomFactor = e.deltaY > 0 ? -0.1 : 0.1
+    setZoomLevel(prev => Math.max(0.1, Math.min(3, prev + zoomFactor)))
   }, [])
 
   const handlePanStart = useCallback((e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- allow wheel events to adjust zoom without holding Ctrl/Meta

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_b_6865b778494483338f6ce8ef2fc29df9