### PR TITLE
Add playful Quack Mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,3 +141,16 @@
 .animate-fade-in {
   animation: fade-in 0.3s ease-out;
 }
+
+@keyframes duck-fly {
+  0% {
+    transform: translateX(-10%);
+  }
+  100% {
+    transform: translateX(110%);
+  }
+}
+
+.duck {
+  animation: duck-fly 8s linear infinite;
+}

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
 import { Badge } from '@/components/ui/badge'
 import { Slider } from '@/components/ui/slider'
+import { Switch } from '@/components/ui/switch'
 import clsx from 'clsx'
 
 interface ControlsPanelProps {
@@ -865,6 +866,20 @@ export default function ControlsPanel({
             <Camera className="mr-2 h-4 w-4" />
             {mounted ? t.cameraPopup : 'Camera Popup'}
           </Button>
+
+          <div className="flex items-center justify-between">
+            <Label className="text-xs text-muted-foreground">{mounted ? t.quackMode : 'Quack Mode'}</Label>
+            <Switch
+              checked={settings.quackMode}
+              onCheckedChange={(value) =>
+                onSettingsChange({
+                  ...settings,
+                  quackMode: value,
+                  color: value ? '#facc15' : settings.color,
+                })
+              }
+            />
+          </div>
 
           <Button variant="ghost" size="sm" className="text-sm w-full justify-start">
             <Settings className="mr-2 h-4 w-4" />

--- a/src/components/VideoCanvas.tsx
+++ b/src/components/VideoCanvas.tsx
@@ -1312,6 +1312,20 @@ const VideoCanvas = forwardRef<VideoCanvasHandle, VideoCanvasProps>(function Vid
                 </Badge>
               </div>
             )}
+
+            {settings.quackMode && (
+              <div className="absolute inset-0 pointer-events-none overflow-hidden">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="duck absolute text-3xl"
+                    style={{ top: `${i * 20 + 10}%`, animationDelay: `${i * 1.5}s` }}
+                  >
+                    🦆
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/VideoPresenter.tsx
+++ b/src/components/VideoPresenter.tsx
@@ -18,6 +18,7 @@ export interface PresenterSettings {
   size: 'small' | 'medium' | 'large' | 'xlarge'
   position: { x: number; y: number }
   isDragging: boolean
+  quackMode: boolean
 }
 
 export type RecordingSource = 'camera' | 'screen' | 'both'
@@ -45,6 +46,7 @@ export default function VideoPresenter() {
     size: 'medium',
     position: { x: 16, y: 16 },
     isDragging: false,
+    quackMode: false,
   })
   const [isPictureInPicture, setIsPictureInPicture] = useState(false)
   const [isSidebarVisible, setIsSidebarVisible] = useState(true)

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -89,6 +89,7 @@ export interface Translations {
   additionalSettings: string
   teleprompter: string
   cameraPopup: string
+  quackMode: string
   advancedOptions: string
   addNote: string
   
@@ -197,6 +198,7 @@ export const translations: Record<Language, Translations> = {
     additionalSettings: 'Additional settings',
     teleprompter: 'Teleprompter',
     cameraPopup: 'Camera Popup',
+    quackMode: 'Quack mode',
     advancedOptions: 'Advanced options',
     addNote: 'Add Note',
     
@@ -304,6 +306,7 @@ export const translations: Record<Language, Translations> = {
     additionalSettings: 'Configurações adicionais',
     teleprompter: 'Teleprompter',
     cameraPopup: 'Pop-up da Câmera',
+    quackMode: 'Modo Quack',
     advancedOptions: 'Opções avançadas',
     addNote: 'Adicionar nota',
     


### PR DESCRIPTION
## Summary
- add Quack Mode translation text
- support Quack Mode in presenter settings
- toggle Quack Mode from the control panel
- animate ducks when Quack Mode is active
- style duck animation in global CSS

## Testing
- `npm run lint`
- `NEXT_FONT_IGNORE_URL_FAILURES=1 npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_b_6865dc54927483339128f289d34453c0