### PR TITLE
Add real-time captions overlay

### DIFF
--- a/src/components/CaptionsOverlay.tsx
+++ b/src/components/CaptionsOverlay.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from '@/lib/useTranslation'
+
+interface CaptionsOverlayProps {
+  isVisible: boolean
+}
+
+export default function CaptionsOverlay({ isVisible }: CaptionsOverlayProps) {
+  const { language } = useTranslation()
+  const [text, setText] = useState('')
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
+
+  useEffect(() => {
+    if (!isVisible) {
+      recognitionRef.current?.stop()
+      return
+    }
+
+    interface WithWebkit extends Window {
+      webkitSpeechRecognition?: typeof SpeechRecognition
+    }
+    const win = window as WithWebkit
+    const SpeechRecognition = win.SpeechRecognition || win.webkitSpeechRecognition
+    if (!SpeechRecognition) {
+      console.warn('SpeechRecognition API not supported')
+      return
+    }
+
+    const recognition: SpeechRecognition = new SpeechRecognition()
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.lang = language === 'pt-br' ? 'pt-BR' : 'en-US'
+
+    recognition.onresult = (e: SpeechRecognitionEvent) => {
+      let latest = ''
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        latest += e.results[i][0].transcript
+      }
+      setText(latest.trim())
+    }
+
+    recognition.onerror = (e) => {
+      console.error('Speech recognition error:', e)
+    }
+
+    recognitionRef.current = recognition
+    recognition.start()
+
+    return () => {
+      recognition.stop()
+    }
+  }, [isVisible, language])
+
+  if (!isVisible) return null
+
+  return (
+    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-black/70 text-white px-3 py-1 rounded text-sm pointer-events-none max-w-full">
+      {text}
+    </div>
+  )
+}

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -28,6 +28,7 @@ interface ControlsPanelProps {
   recordedMimeType?: string
   onPictureInPicture: () => void
   onToggleTeleprompter: () => void
+  onToggleCaptions: () => void
   onToggleCameraPopup: () => void
   onAddNote: () => void
   exportFormat: ExportFormat
@@ -51,6 +52,7 @@ export default function ControlsPanel({
   recordedMimeType,
   onPictureInPicture,
   onToggleTeleprompter,
+  onToggleCaptions,
   onToggleCameraPopup,
   onAddNote,
   exportFormat,
@@ -846,6 +848,15 @@ export default function ControlsPanel({
           >
             <Type className="mr-2 h-4 w-4" />
             {mounted ? t.teleprompter : 'Teleprompter'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-sm w-full justify-start"
+            onClick={onToggleCaptions}
+          >
+            <Video className="mr-2 h-4 w-4" />
+            {mounted ? t.captions : 'Captions'}
           </Button>
           <Button
             variant="ghost"

--- a/src/components/VideoPresenter.tsx
+++ b/src/components/VideoPresenter.tsx
@@ -5,6 +5,7 @@ import VideoCanvas, { type VideoCanvasHandle } from './VideoCanvas'
 import ControlsPanel from './ControlsPanel'
 import TopBar from './TopBar'
 import Teleprompter from './Teleprompter'
+import CaptionsOverlay from './CaptionsOverlay'
 import { videoExporter, type ExportFormat, type ConversionProgress } from '@/lib/videoConverter'
 import { useTranslation } from '@/lib/useTranslation'
 
@@ -32,6 +33,7 @@ export default function VideoPresenter() {
   const [recordingSource, setRecordingSource] = useState<RecordingSource>('camera')
   const [screenStream, setScreenStream] = useState<MediaStream | null>(null)
   const [isTeleprompterVisible, setIsTeleprompterVisible] = useState(false)
+  const [areCaptionsVisible, setAreCaptionsVisible] = useState(false)
   const [isCameraPopupOpen, setIsCameraPopupOpen] = useState(false)
   const [exportFormat, setExportFormat] = useState<ExportFormat>('webm')
   const [isConverting, setIsConverting] = useState(false)
@@ -654,6 +656,10 @@ export default function VideoPresenter() {
     setIsTeleprompterVisible(!isTeleprompterVisible)
   }
 
+  const handleToggleCaptions = () => {
+    setAreCaptionsVisible(!areCaptionsVisible)
+  }
+
   const handleToggleCameraPopup = () => {
     if (isCameraPopupOpen) {
       // Close popup
@@ -909,6 +915,7 @@ export default function VideoPresenter() {
               recordedMimeType={recordedMimeType}
               onPictureInPicture={handlePictureInPicture}
               onToggleTeleprompter={handleToggleTeleprompter}
+              onToggleCaptions={handleToggleCaptions}
               onToggleCameraPopup={handleToggleCameraPopup}
               onAddNote={handleAddNote}
               exportFormat={exportFormat}
@@ -926,6 +933,7 @@ export default function VideoPresenter() {
         onToggleVisibility={handleToggleTeleprompter}
         isRecording={isRecording}
       />
+      <CaptionsOverlay isVisible={areCaptionsVisible} />
     </div>
   )
-} 
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -88,6 +88,7 @@ export interface Translations {
   // Additional Settings
   additionalSettings: string
   teleprompter: string
+  captions: string
   cameraPopup: string
   advancedOptions: string
   addNote: string
@@ -196,6 +197,7 @@ export const translations: Record<Language, Translations> = {
     // Additional Settings
     additionalSettings: 'Additional settings',
     teleprompter: 'Teleprompter',
+    captions: 'Captions',
     cameraPopup: 'Camera Popup',
     advancedOptions: 'Advanced options',
     addNote: 'Add Note',
@@ -303,6 +305,7 @@ export const translations: Record<Language, Translations> = {
     // Additional Settings
     additionalSettings: 'Configurações adicionais',
     teleprompter: 'Teleprompter',
+    captions: 'Legendas',
     cameraPopup: 'Pop-up da Câmera',
     advancedOptions: 'Opções avançadas',
     addNote: 'Adicionar nota',


### PR DESCRIPTION
## Summary
- support captions text in i18n translations
- add button to toggle live captions in the controls panel
- add captions state and overlay component in VideoPresenter
- implement `CaptionsOverlay` component using Web Speech API

## Testing
- `npm install`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_b_6866a38a05ec83339608d50d00c5ebcc