### PR TITLE
Add cloud upload options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A professional video presentation and recording application built with Next.js, 
 - **High-Quality Output**: MP4/WebM export with configurable bitrates
 - **Real-Time Timer**: Live recording duration display
 - **One-Click Download**: Instant video file download after recording
+- **Cloud Upload**: Save recordings directly to Google Drive or Dropbox
 
 ### 🎨 Video Customization
 - **Drag & Drop Positioning**: Move video anywhere on the canvas
@@ -87,6 +88,7 @@ npm run dev
 4. **Start Recording**: Click the red record button
 5. **Drag Video**: Click and drag the video box to reposition
 6. **Stop & Download**: Stop recording and download your video
+7. **Upload to Cloud**: Use the Drive or Dropbox buttons to save online
 
 ## 🔧 Configuration
 

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -26,6 +26,8 @@ interface ControlsPanelProps {
   onDownloadRecording: (format?: ExportFormat) => void
   onClearRecording?: () => void
   recordedMimeType?: string
+  onUploadDrive: () => void
+  onUploadDropbox: () => void
   onPictureInPicture: () => void
   onToggleTeleprompter: () => void
   onToggleCameraPopup: () => void
@@ -49,6 +51,8 @@ export default function ControlsPanel({
   onDownloadRecording,
   onClearRecording,
   recordedMimeType,
+  onUploadDrive,
+  onUploadDropbox,
   onPictureInPicture,
   onToggleTeleprompter,
   onToggleCameraPopup,
@@ -517,10 +521,30 @@ export default function ControlsPanel({
                       size="sm"
                       className="text-xs"
                     >
-                                              <Video className="h-3 w-3 mr-1" />
-                        {mounted ? t.recordAgain : 'Record Again'}
+                      <Video className="h-3 w-3 mr-1" />
+                      {mounted ? t.recordAgain : 'Record Again'}
                     </Button>
                   )}
+                </div>
+                <div className="grid grid-cols-2 gap-2 mt-2">
+                  <Button
+                    onClick={onUploadDrive}
+                    variant="outline"
+                    size="sm"
+                    className="text-xs"
+                  >
+                    <Upload className="h-3 w-3 mr-1" />
+                    {mounted ? t.uploadDrive : 'Upload to Drive'}
+                  </Button>
+                  <Button
+                    onClick={onUploadDropbox}
+                    variant="outline"
+                    size="sm"
+                    className="text-xs"
+                  >
+                    <Upload className="h-3 w-3 mr-1" />
+                    {mounted ? t.uploadDropbox : 'Upload to Dropbox'}
+                  </Button>
                 </div>
               </div>
             )}

--- a/src/components/VideoPresenter.tsx
+++ b/src/components/VideoPresenter.tsx
@@ -6,6 +6,7 @@ import ControlsPanel from './ControlsPanel'
 import TopBar from './TopBar'
 import Teleprompter from './Teleprompter'
 import { videoExporter, type ExportFormat, type ConversionProgress } from '@/lib/videoConverter'
+import { uploadToGoogleDrive, uploadToDropbox } from '@/lib/cloudUploader'
 import { useTranslation } from '@/lib/useTranslation'
 
 
@@ -534,6 +535,34 @@ export default function VideoPresenter() {
     setRecordingDuration(0)
   }
 
+  const uploadRecordingToDrive = async () => {
+    if (!downloadUrl) return
+    const token = prompt('Google Drive access token')
+    if (!token) return
+    try {
+      const blob = await fetch(downloadUrl).then(r => r.blob())
+      const filename = `video-presentation-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.${videoExporter.getFormatInfo(exportFormat).extension}`
+      await uploadToGoogleDrive(blob, filename, token)
+      alert('Uploaded to Drive!')
+    } catch (error) {
+      alert(`Upload failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+  }
+
+  const uploadRecordingToDropbox = async () => {
+    if (!downloadUrl) return
+    const token = prompt('Dropbox access token')
+    if (!token) return
+    try {
+      const blob = await fetch(downloadUrl).then(r => r.blob())
+      const filename = `video-presentation-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.${videoExporter.getFormatInfo(exportFormat).extension}`
+      await uploadToDropbox(blob, filename, token)
+      alert('Uploaded to Dropbox!')
+    } catch (error) {
+      alert(`Upload failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+  }
+
   const handlePictureInPicture = async () => {
     try {
       if (videoRef.current) {
@@ -906,6 +935,8 @@ export default function VideoPresenter() {
               downloadUrl={downloadUrl}
               onDownloadRecording={downloadRecording}
               onClearRecording={clearRecording}
+              onUploadDrive={uploadRecordingToDrive}
+              onUploadDropbox={uploadRecordingToDropbox}
               recordedMimeType={recordedMimeType}
               onPictureInPicture={handlePictureInPicture}
               onToggleTeleprompter={handleToggleTeleprompter}

--- a/src/lib/cloudUploader.ts
+++ b/src/lib/cloudUploader.ts
@@ -1,0 +1,36 @@
+'use client'
+
+export async function uploadToGoogleDrive(blob: Blob, filename: string, token: string): Promise<void> {
+  const metadata = { name: filename }
+  const formData = new FormData()
+  formData.append('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }))
+  formData.append('file', blob)
+
+  const res = await fetch('https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: formData
+  })
+
+  if (!res.ok) {
+    throw new Error(`Google Drive upload failed: ${res.statusText}`)
+  }
+}
+
+export async function uploadToDropbox(blob: Blob, filename: string, token: string): Promise<void> {
+  const res = await fetch('https://content.dropboxapi.com/2/files/upload', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Dropbox-API-Arg': JSON.stringify({ path: `/${filename}`, mode: 'add', autorename: true }),
+      'Content-Type': 'application/octet-stream'
+    },
+    body: blob
+  })
+
+  if (!res.ok) {
+    throw new Error(`Dropbox upload failed: ${res.statusText}`)
+  }
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -52,6 +52,8 @@ export interface Translations {
   recordAgain: string
   converting: string
   conversionProgress: string
+  uploadDrive: string
+  uploadDropbox: string
   
   // Picture in Picture
   stayVisible: string
@@ -160,6 +162,8 @@ export const translations: Record<Language, Translations> = {
     recordAgain: 'Record Again',
     converting: 'Converting to',
     conversionProgress: 'This may take a few moments...',
+    uploadDrive: 'Upload to Drive',
+    uploadDropbox: 'Upload to Dropbox',
     
     // Picture in Picture
     stayVisible: 'Stay Visible',
@@ -267,6 +271,8 @@ export const translations: Record<Language, Translations> = {
     recordAgain: 'Gravar Novamente',
     converting: 'Convertendo para',
     conversionProgress: 'Isso pode levar alguns momentos...',
+    uploadDrive: 'Enviar para o Drive',
+    uploadDropbox: 'Enviar para o Dropbox',
     
     // Picture in Picture
     stayVisible: 'Manter Visível',


### PR DESCRIPTION
## Summary
- support uploading finished recordings to Google Drive or Dropbox
- expose new upload buttons in the controls panel
- keep translations up to date for both languages
- document cloud upload in the README

## Testing
- `npm install`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_b_6866a39af37c8333855ca211a8d77b42