### PR TITLE
Add virtual camera popup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A professional video presentation and recording application built with Next.js, 
 - **Boundary Constraints**: Video stays within canvas bounds
 - **Position Reset**: One-click return to center
 - **Smooth Animations**: CSS transitions for professional feel
+- **Virtual Camera Output**: Present your feed as a virtual webcam
 
 ## 🚀 Getting Started
 

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -29,6 +29,7 @@ interface ControlsPanelProps {
   onPictureInPicture: () => void
   onToggleTeleprompter: () => void
   onToggleCameraPopup: () => void
+  onToggleVirtualCamera: () => void
   onAddNote: () => void
   exportFormat: ExportFormat
   onExportFormatChange: (format: ExportFormat) => void
@@ -52,6 +53,7 @@ export default function ControlsPanel({
   onPictureInPicture,
   onToggleTeleprompter,
   onToggleCameraPopup,
+  onToggleVirtualCamera,
   onAddNote,
   exportFormat,
   onExportFormatChange,
@@ -864,6 +866,15 @@ export default function ControlsPanel({
           >
             <Camera className="mr-2 h-4 w-4" />
             {mounted ? t.cameraPopup : 'Camera Popup'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-sm w-full justify-start"
+            onClick={onToggleVirtualCamera}
+          >
+            <Video className="mr-2 h-4 w-4" />
+            {mounted ? t.virtualCamera : 'Virtual Camera'}
           </Button>
 
           <Button variant="ghost" size="sm" className="text-sm w-full justify-start">

--- a/src/components/VideoCanvas.tsx
+++ b/src/components/VideoCanvas.tsx
@@ -10,6 +10,7 @@ import DocumentViewer from './DocumentViewer'
 
 export interface VideoCanvasHandle {
   addNote: () => void
+  getCanvasStream: () => MediaStream | null
 }
 
 interface VideoCanvasProps {
@@ -536,7 +537,10 @@ const VideoCanvas = forwardRef<VideoCanvasHandle, VideoCanvasProps>(function Vid
     setIsVideoSelected(false)
   }, [boardItems, zoomLevel])
 
-  useImperativeHandle(ref, () => ({ addNote }))
+  useImperativeHandle(ref, () => ({
+    addNote,
+    getCanvasStream: () => canvasRef.current ? canvasRef.current.captureStream(30) : null
+  }))
 
   // Video resize handler
   const handleVideoResizeMouseDown = useCallback((e: React.MouseEvent, handle: string) => {

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -89,6 +89,7 @@ export interface Translations {
   additionalSettings: string
   teleprompter: string
   cameraPopup: string
+  virtualCamera: string
   advancedOptions: string
   addNote: string
   
@@ -197,6 +198,7 @@ export const translations: Record<Language, Translations> = {
     additionalSettings: 'Additional settings',
     teleprompter: 'Teleprompter',
     cameraPopup: 'Camera Popup',
+    virtualCamera: 'Virtual Camera',
     advancedOptions: 'Advanced options',
     addNote: 'Add Note',
     
@@ -304,6 +306,7 @@ export const translations: Record<Language, Translations> = {
     additionalSettings: 'Configurações adicionais',
     teleprompter: 'Teleprompter',
     cameraPopup: 'Pop-up da Câmera',
+    virtualCamera: 'Câmera Virtual',
     advancedOptions: 'Opções avançadas',
     addNote: 'Adicionar nota',
     


### PR DESCRIPTION
## Summary
- enable a virtual camera popup that streams the canvas with audio
- update control panel to toggle the virtual camera
- expose canvas stream via `VideoCanvasHandle`
- extend translations and docs for virtual camera feature

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_6866a3a086e883338e6799bd42b6a4e9