### PR TITLE
Add mobile remote control

### DIFF
--- a/src/app/api/control/route.ts
+++ b/src/app/api/control/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+let lastCommand: string | null = null
+
+export async function POST(req: NextRequest) {
+  const { command } = await req.json()
+  lastCommand = command
+  return NextResponse.json({ status: 'ok' })
+}
+
+export async function GET() {
+  const command = lastCommand
+  lastCommand = null
+  return NextResponse.json({ command })
+}

--- a/src/app/remote/page.tsx
+++ b/src/app/remote/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useState } from 'react'
+
+async function sendCommand(command: string) {
+  await fetch('/api/control', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ command })
+  })
+}
+
+export default function RemotePage() {
+  const [loading, setLoading] = useState(false)
+
+  const handle = async (cmd: string) => {
+    setLoading(true)
+    await sendCommand(cmd)
+    setLoading(false)
+  }
+
+  return (
+    <div className='p-4 space-y-4 text-center'>
+      <h1 className='text-xl font-semibold'>Remote Control</h1>
+      <div className='flex flex-col gap-2'>
+        <button className='bg-blue-600 text-white px-4 py-2 rounded' onClick={() => handle('startRecording')} disabled={loading}>Start Recording</button>
+        <button className='bg-blue-600 text-white px-4 py-2 rounded' onClick={() => handle('stopRecording')} disabled={loading}>Stop Recording</button>
+        <button className='bg-green-600 text-white px-4 py-2 rounded' onClick={() => handle('teleprompterPlay')} disabled={loading}>Teleprompter Play</button>
+        <button className='bg-green-600 text-white px-4 py-2 rounded' onClick={() => handle('teleprompterPause')} disabled={loading}>Teleprompter Pause</button>
+        <button className='bg-green-600 text-white px-4 py-2 rounded' onClick={() => handle('teleprompterUp')} disabled={loading}>Teleprompter Up</button>
+        <button className='bg-green-600 text-white px-4 py-2 rounded' onClick={() => handle('teleprompterDown')} disabled={loading}>Teleprompter Down</button>
+        <button className='bg-yellow-600 text-white px-4 py-2 rounded' onClick={() => handle('toggleTeleprompter')} disabled={loading}>Toggle Teleprompter</button>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/Teleprompter.tsx
+++ b/src/components/Teleprompter.tsx
@@ -24,9 +24,11 @@ interface TeleprompterProps {
   isVisible: boolean
   onToggleVisibility: () => void
   isRecording?: boolean
+  remoteCommand?: string | null
+  onRemoteCommandHandled?: () => void
 }
 
-export default function Teleprompter({ isVisible, onToggleVisibility, isRecording = false }: TeleprompterProps) {
+export default function Teleprompter({ isVisible, onToggleVisibility, isRecording = false, remoteCommand, onRemoteCommandHandled }: TeleprompterProps) {
   const [text, setText] = useState(`Welcome to your video presentation!
 
 Today we'll be covering several important topics that will help you understand the key concepts we're discussing.
@@ -71,6 +73,26 @@ Thank you for watching, and let's begin!`)
   const lastTimestampRef = useRef<number>(0)
   const teleprompterRef = useRef<HTMLDivElement>(null)
   const popupWindowRef = useRef<Window | null>(null)
+
+  // Apply remote commands
+  useEffect(() => {
+    if (!remoteCommand) return
+    switch (remoteCommand) {
+      case 'teleprompterPlay':
+        startScrolling()
+        break
+      case 'teleprompterPause':
+        stopScrolling()
+        break
+      case 'teleprompterUp':
+        scrollUp()
+        break
+      case 'teleprompterDown':
+        scrollDown()
+        break
+    }
+    if (onRemoteCommandHandled) onRemoteCommandHandled()
+  }, [remoteCommand, onRemoteCommandHandled])
 
   const startScrolling = () => {
     if (!scrollContainerRef.current) return


### PR DESCRIPTION
## Summary
- add API route to relay remote commands
- add phone-friendly remote control page
- wire VideoPresenter and Teleprompter to process remote commands

## Testing
- `npm install`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_b_6866a3a63db48333a2f781e7ae8f6193